### PR TITLE
Remove obsolete dependency on SIX (#179)

### DIFF
--- a/pyxnat/core/attributes.py
+++ b/pyxnat/core/attributes.py
@@ -1,9 +1,5 @@
 import difflib
-import six
-if six.PY3:
-    from urllib.parse import quote
-elif six.PY2:
-    from urllib import quote
+from urllib.parse import quote
 
 from .jsonutil import JsonTable
 from .uriutil import uri_parent

--- a/pyxnat/core/errors.py
+++ b/pyxnat/core/errors.py
@@ -1,9 +1,6 @@
 import re
 
 from lxml import etree
-import six
-if six.PY3:
-    unicode = str
 
 # parsing functions
 
@@ -69,7 +66,7 @@ def catch_error(msg_or_exception, full_response=None):
         msg_or_exception = msg_or_exception.decode()
 
     # handle errors returned by the xnat server
-    if isinstance(msg_or_exception, (str, unicode)):
+    if isinstance(msg_or_exception, str):
         # parse the message
         msg = msg_or_exception
         error = parse_error_message(msg)

--- a/pyxnat/core/interfaces.py
+++ b/pyxnat/core/interfaces.py
@@ -9,12 +9,7 @@ try:
 except ImportError:
     socks = None
 
-import six
-if six.PY2:
-    from urlparse import urlparse
-    input = raw_input
-elif six.PY3:
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from .select import Select
 from .help import Inspector, GraphData, PaintGraph, _DRAW_GRAPHS

--- a/pyxnat/core/jsonutil.py
+++ b/pyxnat/core/jsonutil.py
@@ -3,12 +3,7 @@ import copy
 from fnmatch import fnmatch
 import json
 
-import six
-if six.PY2:
-    from StringIO import StringIO
-elif six.PY3:
-    unicode = str
-    from io import StringIO
+from io import StringIO
 
 # jdata is a list of dicts
 
@@ -111,16 +106,11 @@ def get_selection(jdata, columns):
 def csv_to_json(csv_str):
 
     import csv
-    import six
-    if six.PY2:
+    try:
         csv_reader = csv.reader(StringIO(csv_str), delimiter=',',
                                 quotechar='"')
-    elif six.PY3:
-        try:
-            csv_reader = csv.reader(StringIO(csv_str), delimiter=',',
-                                    quotechar='"')
-        except TypeError:
-            csv_reader = csv.reader(StringIO(csv_str.decode('utf-8')),
+    except TypeError:
+        csv_reader = csv.reader(StringIO(csv_str.decode('utf-8')),
                                     delimiter=',', quotechar='"')
     headers = next(csv_reader)
     ans = [dict(zip(headers, entry)) for entry in csv_reader]
@@ -172,7 +162,7 @@ class JsonTable(object):
         return iter(self.data)
 
     def __getitem__(self, name):
-        if isinstance(name, (str, unicode)):
+        if isinstance(name, str):
             return self.get(name)
         elif isinstance(name, int):
             return self.__class__([self.data[name]], self.order_by)
@@ -296,7 +286,7 @@ class JsonTable(object):
                                 quotechar='"', quoting=csv.QUOTE_MINIMAL)
 
         for entry in self.as_list():
-            csv_writer.writerow(unicode(entry))
+            csv_writer.writerow(str(entry))
 
         return str_buffer.getvalue()
 

--- a/pyxnat/core/pipelines.py
+++ b/pyxnat/core/pipelines.py
@@ -1,10 +1,6 @@
 import os.path as op
 
-# import six
-# if six.PY2:
-#     from urllib2 import urlopen
-# elif six.PY3:
-#     from urllib.request import urlopen
+# from urllib.request import urlopen
 
 # import smtplib
 # from copy import deepcopy

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -34,13 +34,7 @@ from . import derivatives
 import types
 import pkgutil
 import inspect
-import six
-from six import string_types, add_metaclass
-if six.PY2:
-    from urllib import quote, unquote  # Python 2.X
-elif six.PY3:
-    from urllib.parse import quote, unquote
-    unicode = str
+from urllib.parse import quote, unquote
 
 DEBUG = False
 
@@ -225,7 +219,7 @@ class EObject(object):
         if filters:
             get_id += '&' + \
                 '&'.join('%s=%s' % (item[0], item[1])
-                         if isinstance(item[1], string_types)
+                         if isinstance(item[1], str)
                          else '%s=%s' % (item[0],
                                          ','.join([val for val in item[1]]))
                          for item in filters.items())
@@ -593,12 +587,12 @@ class CObject(object):
         self._filters = filters
         self._nested = nested
 
-        if isinstance(cbase, string_types):
+        if isinstance(cbase, str):
             self._ctype = 'cobjectcuri'
         elif isinstance(cbase, CObject):
             self._ctype = 'cobjectcobject'
         elif isinstance(cbase, list) and cbase:
-            if isinstance(cbase[0], string_types):
+            if isinstance(cbase[0], str):
                 self._ctype = 'cobjecteuris'
             if isinstance(cbase[0], EObject):
                 self._ctype = 'cobjecteobjects'
@@ -634,7 +628,7 @@ class CObject(object):
             if self._filters:
                 query_string += '&' + '&'.join(
                     '%s=%s' % (item[0], item[1])
-                    if isinstance(item[1], (str, unicode))
+                    if isinstance(item[1], str)
                     else '%s=%s' % (
                         item[0], ','.join([val for val in item[1]]))
                     for item in self._filters.items()
@@ -940,14 +934,14 @@ class CObject(object):
             :func:`search.Search`
         """
 
-        if isinstance(constraints, (str, unicode)):
+        if isinstance(constraints, str):
             constraints = rpn_contraints(constraints)
         elif isinstance(template, (tuple)):
             tmp_bundle = self._intf.manage.search.get_template(
                 template[0], True)
             tmp_bundle = tmp_bundle % template[1]
             constraints = query_from_xml(tmp_bundle)['constraints']
-        elif isinstance(query, (str, unicode)):
+        elif isinstance(query, str):
             tmp_bundle = self._intf.manage.search.get(query, 'xml')
             constraints = query_from_xml(tmp_bundle)['constraints']
         elif isinstance(constraints, list):
@@ -1020,8 +1014,7 @@ class CObject(object):
 # specialized classes
 
 
-@add_metaclass(ElementType)
-class Project(EObject):
+class Project(EObject, metaclass=ElementType):
 
     def __init__(self, uri, interface):
         """
@@ -1437,8 +1430,7 @@ class Project(EObject):
         return self.attrs.get('description')
 
 
-@add_metaclass(ElementType)
-class Subject(EObject):
+class Subject(EObject, metaclass=ElementType):
 
     def datatype(self):
         return 'xnat:subjectData'
@@ -1564,8 +1556,7 @@ class Subject(EObject):
         self._intf._exec(join_uri(self._uri, 'projects', project), 'DELETE')
 
 
-@add_metaclass(ElementType)
-class Experiment(EObject):
+class Experiment(EObject, metaclass=ElementType):
 
     def __init__(self, cbase, interface):
         items = cbase.split('/')
@@ -1738,8 +1729,7 @@ class Experiment(EObject):
             self._intf._exec(self._uri + options, 'PUT', body=[])
 
 
-@add_metaclass(ElementType)
-class Assessor(EObject):
+class Assessor(EObject, metaclass=ElementType):
 
     def __init__(self, uri, interface):
         EObject.__init__(self, uri, interface)
@@ -1763,8 +1753,7 @@ class Assessor(EObject):
         return self.xpath('//xnat:addParam/attribute::*')
 
 
-@add_metaclass(ElementType)
-class Reconstruction(EObject):
+class Reconstruction(EObject, metaclass=ElementType):
 
     def __init__(self, uri, interface):
         EObject.__init__(self, uri, interface)
@@ -1775,8 +1764,7 @@ class Reconstruction(EObject):
         return 'xnat:reconstructedImageData'
 
 
-@add_metaclass(ElementType)
-class Scan(EObject):
+class Scan(EObject, metaclass=ElementType):
 
     def __repr__(self):
         interface = self._intf
@@ -1825,8 +1813,7 @@ class Scan(EObject):
         return self.xpath('//xnat:addParam/attribute::*')
 
 
-@add_metaclass(ElementType)
-class Resource(EObject):
+class Resource(EObject, metaclass=ElementType):
 
     def __repr__(self):
 
@@ -2103,8 +2090,7 @@ class In_Resource(Resource):
         return Klass(uri_parent(uri), self._intf)
 
 
-@add_metaclass(ElementType)
-class Out_Resource(Resource):
+class Out_Resource(Resource, metaclass=ElementType):
 
     def parent(self):
         uri = uri_grandparent(self._uri)
@@ -2112,8 +2098,7 @@ class Out_Resource(Resource):
         return Klass(uri_parent(uri), self._intf)
 
 
-@add_metaclass(ElementType)
-class File(EObject):
+class File(EObject, metaclass=ElementType):
     """ EObject for files stored in XNAT.
     """
 
@@ -2370,23 +2355,19 @@ class File(EObject):
         return info['last-modified']
 
 
-@add_metaclass(ElementType)
-class In_File(File):
+class In_File(File, metaclass=ElementType):
     pass
 
 
-@add_metaclass(ElementType)
-class Out_File(File):
+class Out_File(File, metaclass=ElementType):
     pass
 
 
-@add_metaclass(CollectionType)
-class Projects(CObject):
+class Projects(CObject, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class Subjects(CObject):
+class Subjects(CObject, metaclass=CollectionType):
 
     def sharing(self, projects=[]):
         return Subjects([eobj for eobj in self
@@ -2402,8 +2383,7 @@ class Subjects(CObject):
             eobj.unshare(project)
 
 
-@add_metaclass(CollectionType)
-class Experiments(CObject):
+class Experiments(CObject, metaclass=CollectionType):
 
     def sharing(self, projects=[]):
         return Experiments([eobj for eobj in self
@@ -2419,8 +2399,7 @@ class Experiments(CObject):
             eobj.unshare(project)
 
 
-@add_metaclass(CollectionType)
-class Assessors(CObject):
+class Assessors(CObject, metaclass=CollectionType):
 
     def download(self, dest_dir, type="ALL",
                  name=None, extract=False, safe=False, removeZip=False):
@@ -2431,8 +2410,7 @@ class Assessors(CObject):
                                       extract, safe, removeZip)
 
 
-@add_metaclass(CollectionType)
-class Reconstructions(CObject):
+class Reconstructions(CObject, metaclass=CollectionType):
 
     def download(self, dest_dir, type="ALL",
                  name=None, extract=False, safe=False, removeZip=False):
@@ -2443,8 +2421,7 @@ class Reconstructions(CObject):
                                       extract, safe, removeZip)
 
 
-@add_metaclass(CollectionType)
-class Scans(CObject):
+class Scans(CObject, metaclass=CollectionType):
 
     def download(self, dest_dir, type="ALL",
                  name=None, extract=False, safe=False, removeZip=False):
@@ -2456,33 +2433,27 @@ class Scans(CObject):
                                       extract, safe, removeZip)
 
 
-@add_metaclass(CollectionType)
-class Resources(CObject):
+class Resources(CObject, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class In_Resources(Resources):
+class In_Resources(Resources, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class Out_Resources(Resources):
+class Out_Resources(Resources, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class Files(CObject):
+class Files(CObject, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class In_Files(Files):
+class In_Files(Files, metaclass=CollectionType):
     pass
 
 
-@add_metaclass(CollectionType)
-class Out_Files(Files):
+class Out_Files(Files, metaclass=CollectionType):
     pass
 
 # Utility functions for downloading and extracting zip archives
@@ -2533,7 +2504,7 @@ def rewrite_query(interface, join_field,
             _new_f.append('OR')
             _new_filter.append(_new_f)
 
-        elif isinstance(_f, (str, unicode)):
+        elif isinstance(_f, str):
             _new_filter.append(_f)
 
         else:

--- a/pyxnat/core/schema.py
+++ b/pyxnat/core/schema.py
@@ -1,4 +1,3 @@
-from six import string_types
 # REST collection resources tree
 resources_tree = {
     'projects': ['subjects', 'resources'],
@@ -69,17 +68,17 @@ def datatype_attributes(root, datatype):
         elements = []
 
         for child in node.iterchildren():
-            if isinstance(child.tag, string_types) \
+            if isinstance(child.tag, str) \
                and child.tag.split('}')[1] == 'element':
                 elements.append('%s/%s' % (pathsofar, child.get('name')))
                 elements.extend(_iterchildren(child, '%s/%s' %
                                 (pathsofar, child.get('name'))))
 
-            elif isinstance(child.tag, string_types) and \
+            elif isinstance(child.tag, str) and \
                     child.tag.split('}')[1] == 'attribute':
                 elements.append('%s/%s' % (pathsofar, child.get('name')))
 
-            elif isinstance(child.tag, string_types) \
+            elif isinstance(child.tag, str) \
                     and child.tag.split('}')[1] == 'extension':
 
                 ct_xpath = "/xs:schema/xs:complexType[@name='%s']" % \

--- a/pyxnat/core/search.py
+++ b/pyxnat/core/search.py
@@ -1,17 +1,6 @@
 import csv
 import difflib
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-try:
-    unicode
-    import sys
-    reload(sys)  # Reload does the trick!
-    sys.setdefaultencoding('UTF8')
-except NameError:
-    unicode = str
-from six import string_types
+from io import StringIO
 
 from lxml import etree
 
@@ -130,7 +119,7 @@ def build_search_document(root_element_name, columns, criteria_set,
 def build_criteria_set(container_node, criteria_set):
 
     for criteria in criteria_set:
-        if isinstance(criteria, string_types):
+        if isinstance(criteria, str):
             container_node.set('method', criteria)
 
         if isinstance(criteria, (list)):
@@ -500,7 +489,7 @@ class SearchManager(object):
                                            constraint[1],
                                            '%%(%s)s' % constraint[2])
                                           )
-                elif isinstance(constraint, (unicode, str)):
+                elif isinstance(constraint, str):
                     query_template.append(constraint)
                 elif isinstance(constraint, list):
                     query_template.append(_make_template(constraint))
@@ -689,7 +678,7 @@ class Search(object):
         """
         self._intf._get_entry_point()
 
-        if isinstance(constraints, (str, unicode)):
+        if isinstance(constraints, str):
             constraints = rpn_contraints(constraints)
         elif isinstance(template, (tuple)):
             tmp_bundle = self._intf.manage.search.get_template(
@@ -697,7 +686,7 @@ class Search(object):
 
             tmp_bundle = tmp_bundle % template[1]
             constraints = query_from_xml(tmp_bundle)['constraints']
-        elif isinstance(query, (str, unicode)):
+        elif isinstance(query, str):
             tmp_bundle = self._intf.manage.search.get(query, 'xml')
             constraints = query_from_xml(tmp_bundle)['constraints']
         elif isinstance(constraints, list):

--- a/pyxnat/tests/resources_test.py
+++ b/pyxnat/tests/resources_test.py
@@ -1,6 +1,5 @@
 import tempfile
 from uuid import uuid1
-from six import string_types
 import os.path as op
 import os
 from pyxnat import Interface
@@ -182,7 +181,7 @@ def test_11_get_copy_file():
 @skip_if_no_network
 def test_12_file_last_modified():
     f = subj_1.resource('test').file('hello.txt')
-    assert isinstance(f.last_modified(), string_types)
+    assert isinstance(f.last_modified(), str)
     assert len(f.last_modified()) > 0
     f.delete()
     assert(not f.exists())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
 lxml>=4.3.2
 requests>=2.20
 pathlib>=1.0.1
-six>=1.15
-future>=0.16
 # testing
 pytest>=7.1
 pytest-cov>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 lxml>=4.3.2
 requests>=2.20
 pathlib>=1.0.1
-six>=1.15
-future>=0.16

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,7 @@ setuptools.setup(name='pyxnat',
                  scripts=['bin/sessionmirror.py'],
                  install_requires=['lxml>=4.3',
                                    'requests>=2.20',
-                                   'pathlib>=1.0',
-                                   'six>=1.15',
-                                   'future>=0.16'],
+                                   'pathlib>=1.0'],
                  package_data={'pyxnat': ['README.rst'], },
 
                  )


### PR DESCRIPTION
Packages `six` & `future` were compatibility layers to help migrate from Python 2 in small steps. They are not required anymore as Python 2.x is not supported anymore (https://github.com/pyxnat/pyxnat/pull/159/commits/d46697cd22ef6796b7fd42ed5761376c9fc6b176) and both compatibility packages are unmaintained.
